### PR TITLE
fix(ui): evitar datos viejos al cambiar período

### DIFF
--- a/src/components/widgets/sections/EstadoNegocioSection.tsx
+++ b/src/components/widgets/sections/EstadoNegocioSection.tsx
@@ -758,6 +758,7 @@ export function EstadoNegocioSection({ locationId }: Props) {
     async function loadExecutiveData() {
       setExecutiveLoading(true)
       setExecutiveError(null)
+      setExecutiveData(null)
       const supabase = getSupabase()
       const currentBounds = monthBounds(currentMonth!)
       const latestBounds = monthBounds(latestMonth!)


### PR DESCRIPTION
﻿## Qué cambia
Limpia el período anterior apenas comienza a cargar una nueva selección para que la frase, los drivers y la tabla nunca queden momentáneamente asociados al mes recién elegido.

## Validación
- `npx tsc --noEmit`
- `npm run lint` (sin errores; warning preexistente en `lib/processors/excelProcessor.ts`)
- Verificación interactiva en STG cambiando julio ↔ junio
