### PR TITLE
feat(security): role-gating on write API routes (owner/super_admin only)

### DIFF
--- a/app/api/pnl/route.ts
+++ b/app/api/pnl/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { computePnL, type PnLInputs } from '@/lib/pnl/formulas'
 import { requireMembership } from '@/lib/api-auth'
+import { WRITE_ROLES } from '@/lib/authz'
 
 interface FinRow {
   org_id:      string
@@ -102,7 +103,7 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'Formato de periodo inválido (esperado YYYY-MM)' }, { status: 400 })
     }
 
-    const authResult = await requireMembership(req, location_id)
+    const authResult = await requireMembership(req, location_id, { roles: WRITE_ROLES })
     if (authResult instanceof Response) return authResult
 
     const rows = buildRows(inputs, org_id, location_id, periodo)

--- a/app/api/upload/[contract_id]/route.ts
+++ b/app/api/upload/[contract_id]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireMembership } from '@/lib/api-auth'
+import { WRITE_ROLES } from '@/lib/authz'
 import { getContract, listContracts } from '@/src/lib/upload/contracts/registry'
 import { runUploadPipeline } from '@/src/lib/upload/pipeline/runPipeline'
 
@@ -38,7 +39,7 @@ export async function POST(
     return NextResponse.json({ error: 'MISSING_LOCATION_ID' }, { status: 400 })
   }
 
-  const authResult = await requireMembership(req, locationId)
+  const authResult = await requireMembership(req, locationId, { roles: WRITE_ROLES })
   if (authResult instanceof Response) return authResult
 
   const dryRun = req.nextUrl.searchParams.get('dry_run') === 'true'

--- a/app/api/upload/cucinago/route.ts
+++ b/app/api/upload/cucinago/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient }       from '@supabase/supabase-js'
 import { requireMembership }  from '@/lib/api-auth'
+import { WRITE_ROLES }        from '@/lib/authz'
 import { getCucinaGoConfig }  from '@/lib/pos-config'
 
 const BATCH     = 500
@@ -202,7 +203,7 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'Faltan campos: from, to, location_id, org_id' }, { status: 400 })
     }
 
-    const authResult = await requireMembership(req, locationId)
+    const authResult = await requireMembership(req, locationId, { roles: WRITE_ROLES })
     if (authResult instanceof Response) return authResult
 
     const supabase = createClient(SUPA_URL!, SUPA_KEY!)

--- a/app/api/upload/financial/route.ts
+++ b/app/api/upload/financial/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import * as XLSX from 'xlsx'
 import { requireMembership } from '@/lib/api-auth'
+import { WRITE_ROLES } from '@/lib/authz'
 
 const BATCH = 500
 
@@ -180,7 +181,7 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'Faltan campos: financial, location_id, org_id' }, { status: 400 })
     }
 
-    const authResult = await requireMembership(req, locationId)
+    const authResult = await requireMembership(req, locationId, { roles: WRITE_ROLES })
     if (authResult instanceof Response) return authResult
 
     const buf               = await pnlFile.arrayBuffer()

--- a/app/api/upload/items/route.ts
+++ b/app/api/upload/items/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireMembership } from '@/lib/api-auth'
+import { WRITE_ROLES } from '@/lib/authz'
 import { getContract } from '@/src/lib/upload/contracts/registry'
 import { runUploadPipeline } from '@/src/lib/upload/pipeline/runPipeline'
 
@@ -19,7 +20,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'Se requiere el archivo items' }, { status: 400 })
   }
 
-  const authResult = await requireMembership(req, locationId)
+  const authResult = await requireMembership(req, locationId, { roles: WRITE_ROLES })
   if (authResult instanceof Response) return authResult
 
   const contract = getContract('maxirest-items')!

--- a/app/api/upload/sales/route.ts
+++ b/app/api/upload/sales/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireMembership } from '@/lib/api-auth'
+import { WRITE_ROLES } from '@/lib/authz'
 import { getContract } from '@/src/lib/upload/contracts/registry'
 import { runUploadPipeline } from '@/src/lib/upload/pipeline/runPipeline'
 
@@ -19,7 +20,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'Se requiere al menos un archivo (ventas o items)' }, { status: 400 })
   }
 
-  const authResult = await requireMembership(req, locationId)
+  const authResult = await requireMembership(req, locationId, { roles: WRITE_ROLES })
   if (authResult instanceof Response) return authResult
 
   const contract = getContract('maxirest-sales')!

--- a/lib/api-auth.ts
+++ b/lib/api-auth.ts
@@ -2,6 +2,7 @@ import { createServerClient } from '@supabase/ssr'
 import { createClient }       from '@supabase/supabase-js'
 import { NextResponse }       from 'next/server'
 import type { NextRequest }   from 'next/server'
+import type { Role }          from '@/types/auth'
 
 /**
  * Validates that the caller has an authenticated session AND an active
@@ -14,13 +15,16 @@ import type { NextRequest }   from 'next/server'
  * In both cases the JWT is validated via supabase.auth.getUser() which hits
  * the Supabase Auth API — it is NOT a local decode and respects token revocation.
  *
- * Role enforcement is NOT included here; it belongs in the role-gating PR.
+ * Pass `opts.roles` to additionally require the membership's role to be in
+ * that list (see lib/authz.ts WRITE_ROLES for the write-route gate) — omit it
+ * for routes where any active membership is sufficient.
  *
  * Returns { userId } on success, or a ready-to-return Response on failure.
  */
 export async function requireMembership(
   req: NextRequest,
   locationId: string,
+  opts?: { roles?: readonly Role[] },
 ): Promise<{ userId: string } | Response> {
   const url     = process.env.NEXT_PUBLIC_SUPABASE_URL!
   const anon    = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
@@ -62,7 +66,7 @@ export async function requireMembership(
   // through locations.org_id anymore.
   const { data, error: memberError } = await svc
     .from('memberships')
-    .select('id')
+    .select('id, role')
     .eq('user_id', userId)
     .eq('location_id', locationId)
     .eq('is_active', true)
@@ -71,6 +75,13 @@ export async function requireMembership(
   if (memberError || !data) {
     return NextResponse.json(
       { error: 'Forbidden: no active membership for this location' },
+      { status: 403 },
+    )
+  }
+
+  if (opts?.roles && !opts.roles.includes(data.role)) {
+    return NextResponse.json(
+      { error: 'Forbidden: role not permitted for this action' },
       { status: 403 },
     )
   }

--- a/lib/authz.ts
+++ b/lib/authz.ts
@@ -1,0 +1,18 @@
+import type { Role } from '@/types/auth'
+
+/**
+ * Single source of truth for which roles may call the mutating API routes
+ * (upload/*, /api/pnl) — passed to requireMembership(req, locationId, { roles: WRITE_ROLES }).
+ *
+ * This answers a different question than the UI-only role lists in
+ * app/role-select/page.tsx (canAccessModule) and app/dashboard/owner/v2/page.tsx
+ * (TABS.allowedRoles): those control what a role SEES (which module tiles /
+ * tabs render). This constant controls what a role is allowed to DO (write).
+ * A role can legitimately see a tab it can't write to — e.g. manager sees the
+ * P&L tab (TABS.allowedRoles includes 'manager') but cannot submit /api/pnl
+ * (not in WRITE_ROLES). That split is intentional, not a bug.
+ *
+ * If you change this list, check whether canAccessModule / TABS.allowedRoles
+ * should change too, so a role is never shown a form it can't actually submit.
+ */
+export const WRITE_ROLES: readonly Role[] = ['owner', 'super_admin']

--- a/tests/api-auth.test.ts
+++ b/tests/api-auth.test.ts
@@ -133,4 +133,41 @@ describe('requireMembership', () => {
     expect(result).toBeInstanceOf(Response)
     expect((result as Response).status).toBe(403)
   })
+
+  // ── opts.roles (write-route gate, e.g. lib/authz.ts WRITE_ROLES) ────────────
+
+  it('403 — active membership but role not in opts.roles', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-manager' } }, error: null })
+    mockMembershipSingle.mockResolvedValue({ data: { id: 'mem-1', role: 'manager' }, error: null })
+
+    const { requireMembership } = await import('@/lib/api-auth')
+    const result = await requireMembership(makeReq(), 'loc-123', { roles: ['owner', 'super_admin'] })
+
+    expect(result).toBeInstanceOf(Response)
+    expect((result as Response).status).toBe(403)
+    const body = await (result as Response).json()
+    expect(body.error).toMatch(/role not permitted/)
+  })
+
+  it('200 — active membership with role in opts.roles', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-owner' } }, error: null })
+    mockMembershipSingle.mockResolvedValue({ data: { id: 'mem-2', role: 'owner' }, error: null })
+
+    const { requireMembership } = await import('@/lib/api-auth')
+    const result = await requireMembership(makeReq(), 'loc-123', { roles: ['owner', 'super_admin'] })
+
+    expect(result).not.toBeInstanceOf(Response)
+    expect((result as { userId: string }).userId).toBe('user-owner')
+  })
+
+  it('200 — opts.roles omitted skips the role check entirely (any active membership passes)', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-staff' } }, error: null })
+    mockMembershipSingle.mockResolvedValue({ data: { id: 'mem-3', role: 'staff' }, error: null })
+
+    const { requireMembership } = await import('@/lib/api-auth')
+    const result = await requireMembership(makeReq(), 'loc-123')
+
+    expect(result).not.toBeInstanceOf(Response)
+    expect((result as { userId: string }).userId).toBe('user-staff')
+  })
 })


### PR DESCRIPTION
requireMembership() gains an optional opts.roles filter; the 6 mutating routes (upload/sales, upload/items, upload/[contract_id], upload/cucinago, upload/financial, pnl) now pass lib/authz.ts WRITE_ROLES. Any active membership regardless of role could previously call these routes.

reconcile/cucinago is excluded — verified read-only (fetches + diffs, no writes) so gating it would remove a legitimate read for manager.