### PR TITLE
Explain upload permission errors

### DIFF
--- a/app/dashboard/upload/page.tsx
+++ b/app/dashboard/upload/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useRef, useCallback } from 'react'
 import Link from 'next/link'
 import { useAuth } from '@/hooks/useAuth'
-import { translateUploadError } from '@/src/lib/upload/error-messages'
+import { resolveUploadApiError, translateUploadError } from '@/src/lib/upload/error-messages'
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -171,6 +171,7 @@ function ResultBanner({ status, result, error }: { status: CardStatus; result: U
   const isOk  = status === 'success'
   const color = isOk ? GREEN : RED
   const bg    = isOk ? 'rgba(34,197,94,0.08)' : 'rgba(239,68,68,0.08)'
+  const errorMessage = !isOk ? translateUploadError(error) : null
   return (
     <div style={{ padding: '12px 16px', background: bg, border: `1px solid ${color}30`, borderRadius: 8, display: 'flex', alignItems: 'flex-start', gap: 10 }}>
       <div style={{ width: 8, height: 8, borderRadius: '50%', background: color, marginTop: 5, flexShrink: 0, boxShadow: `0 0 6px ${color}` }} />
@@ -223,7 +224,10 @@ function ResultBanner({ status, result, error }: { status: CardStatus; result: U
             </>
           )
         ) : (
-          <div style={{ color: '#fca5a5' }}>{error}</div>
+          <div>
+            <div style={{ color: '#fca5a5', fontWeight: 650 }}>{errorMessage?.titulo}</div>
+            <div style={{ color: 'rgba(255,255,255,0.52)', marginTop: 3 }}>{errorMessage?.detalle}</div>
+          </div>
         )}
       </div>
     </div>
@@ -613,7 +617,7 @@ function CardVentas({ locationId, orgId }: { locationId: string; orgId: string }
       const res  = await fetch('/api/upload/sales?dry_run=true', { method: 'POST', body: buildForm() })
       const data = await res.json()
       if (!res.ok || data.error) {
-        setError(data.error ?? `HTTP ${res.status}`)
+        setError(resolveUploadApiError(res.status, data.error))
         setErrorDetails(data.errors ?? [])
         setStatus('error')
         return
@@ -631,7 +635,7 @@ function CardVentas({ locationId, orgId }: { locationId: string; orgId: string }
       const res  = await fetch('/api/upload/sales', { method: 'POST', body: buildForm() })
       const data = await res.json()
       if (!res.ok || data.error) {
-        setError(data.error ?? `HTTP ${res.status}`)
+        setError(resolveUploadApiError(res.status, data.error))
         setErrorDetails(data.errors ?? [])
         setStatus('error')
         return
@@ -721,7 +725,7 @@ function CardItems({ locationId, orgId }: { locationId: string; orgId: string })
       const res  = await fetch('/api/upload/items?dry_run=true', { method: 'POST', body: buildForm() })
       const data = await res.json()
       if (!res.ok || data.error) {
-        setError(data.error ?? `HTTP ${res.status}`)
+        setError(resolveUploadApiError(res.status, data.error))
         setErrorDetails(data.errors ?? [])
         setStatus('error')
         return
@@ -739,7 +743,7 @@ function CardItems({ locationId, orgId }: { locationId: string; orgId: string })
       const res  = await fetch('/api/upload/items', { method: 'POST', body: buildForm() })
       const data = await res.json()
       if (!res.ok || data.error) {
-        setError(data.error ?? `HTTP ${res.status}`)
+        setError(resolveUploadApiError(res.status, data.error))
         setErrorDetails(data.errors ?? [])
         setStatus('error')
         return
@@ -821,7 +825,7 @@ function CardCucinaGo({ locationId, orgId }: { locationId: string; orgId: string
         body: JSON.stringify({ from: desde, to: hasta, location_id: locationId, org_id: orgId }),
       })
       const data = await res.json()
-      if (!res.ok || data.error) { setError(data.error ?? `HTTP ${res.status}`); setStatus('error'); return }
+      if (!res.ok || data.error) { setError(resolveUploadApiError(res.status, data.error)); setStatus('error'); return }
       setResult(data); setStatus('success')
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : String(e)); setStatus('error')

--- a/src/lib/upload/__tests__/error-messages.test.ts
+++ b/src/lib/upload/__tests__/error-messages.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { translateUploadError } from '../error-messages'
+import { resolveUploadApiError, translateUploadError } from '../error-messages'
 
 describe('translateUploadError', () => {
   describe('VALIDATION_FAILED — formato inválido', () => {
@@ -69,6 +69,22 @@ describe('translateUploadError', () => {
     it('Se requiere el archivo', () => {
       const r = translateUploadError('Se requiere el archivo items')
       expect(r.titulo).toContain('Falta el archivo')
+    })
+  })
+
+  describe('Permisos de escritura', () => {
+    it('prioriza el status 403 sobre el mensaje técnico de la API', () => {
+      const error = resolveUploadApiError(403, 'Forbidden: role not permitted for this action')
+      const r = translateUploadError(error)
+
+      expect(error).toBe('HTTP 403')
+      expect(r.titulo).toContain('No tenés permisos')
+      expect(r.detalle).toContain('dueño de la cuenta')
+      expect(r.detalle).toContain('archivo no tiene ningún problema')
+    })
+
+    it('conserva el mensaje de la API para otros status', () => {
+      expect(resolveUploadApiError(422, 'VALIDATION_FAILED')).toBe('VALIDATION_FAILED')
     })
   })
 

--- a/src/lib/upload/error-messages.ts
+++ b/src/lib/upload/error-messages.ts
@@ -20,6 +20,11 @@ function parseMissingCols(detail: string): string {
   return m ? m[1] : ''
 }
 
+export function resolveUploadApiError(status: number, apiError?: string): string {
+  if (status === 403) return 'HTTP 403'
+  return apiError?.trim() || `HTTP ${status}`
+}
+
 export function translateUploadError(
   error: string,
   errors?: string[],
@@ -115,6 +120,14 @@ export function translateUploadError(
     return {
       titulo:  'Falta el archivo',
       detalle: 'Seleccioná el archivo antes de continuar.',
+      tecnico,
+    }
+  }
+
+  if (error === 'HTTP 403') {
+    return {
+      titulo:  'No tenés permisos para cargar datos',
+      detalle: 'Esta función está reservada para el dueño de la cuenta. El archivo no tiene ningún problema.',
       tecnico,
     }
   }


### PR DESCRIPTION
## UI fix
- maps API 403 responses to an explicit permission message
- keeps validation and server errors on their existing paths
- applies the same friendly translation to upload result banners
- adds regression coverage for the status mapping and copy

## Checks
- npx vitest run src/lib/upload/__tests__/error-messages.test.ts
- npx tsc --noEmit
- npm run lint (0 errors; 1 pre-existing warning)
- npm run build