### PR TITLE
fix(authz): gate /dashboard/business-config behind WRITE_ROLES

### DIFF
--- a/lib/page-access.ts
+++ b/lib/page-access.ts
@@ -34,6 +34,7 @@ export const PAGE_ACCESS: readonly { prefix: string; roles: readonly Role[] }[] 
   { prefix: '/dashboard/pnl',       roles: WRITE_ROLES },
   { prefix: '/dashboard/reconcile', roles: WRITE_ROLES },
   { prefix: '/dashboard/upload',    roles: WRITE_ROLES },
+  { prefix: '/dashboard/business-config', roles: WRITE_ROLES },
 ]
 
 export function rolesForPath(pathname: string): readonly Role[] {


### PR DESCRIPTION
## Summary
- Agrega `{ prefix: '/dashboard/business-config', roles: WRITE_ROLES }` a `PAGE_ACCESS` en `lib/page-access.ts`.
- Sin esta entrada, `rolesForPath('/dashboard/business-config')` cae al fallback `ALL_DASHBOARD_ROLES` y un `manager` puede cargar la página server-side antes de que la UI le muestre el estado restringido.
- Coherente con `/api/business-config` y `BUSINESS_CONFIG_KEYS` (`lib/business-config.ts`), que ya restringen escritura a `WRITE_ROLES` (`owner`, `super_admin`).
- Codex está frenado esperando esta entrada.

## Test plan
- [x] `tests/page-access-consistency.test.ts` sigue verde (2/2) — no hay ningún tab/tile existente que apunte a `/dashboard/business-config` hoy, así que el cambio es puramente aditivo, no afecta la subset-check de TABS/MODULES.
- [x] `npx tsc --noEmit` — limpio
- [x] `npx eslint src/ app/` — limpio
- [x] `npx vitest run` — 319 passed, 3 failed (preexistentes en `develop`, no relacionados: `tests/business-config-registry.test.ts` falla por CRLF de Windows en el checkout local, ver PR #52 para el detalle — no aparece en CI Linux), 30 skipped