### PR TITLE
feat(business-config): DELETE para volver una clave a no configurado

### DIFF
--- a/app/api/business-config/route.ts
+++ b/app/api/business-config/route.ts
@@ -28,6 +28,10 @@ interface WriteEntry {
   value: unknown
 }
 
+interface DeleteBody {
+  keys?: string[]
+}
+
 export async function POST(req: NextRequest) {
   const SUPA_URL = process.env.NEXT_PUBLIC_SUPABASE_URL
   const SUPA_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY
@@ -105,6 +109,82 @@ export async function POST(req: NextRequest) {
     }
 
     return NextResponse.json({ success: true, upserted: rows.map(r => r.key) })
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err)
+    console.error('[api/business-config] error:', msg)
+    return NextResponse.json({ error: msg }, { status: 500 })
+  }
+}
+
+/**
+ * Vuelve una o más claves a "no configurado" (fila ausente) para una
+ * location. Única forma de desconfigurar — no hay PATCH con value=null
+ * ni ninguna otra vía que lo infiera (ver contrato en
+ * docs/qa/H3-PARTE-A-BUSINESS-CONFIG.md). Mismo gate que POST
+ * (WRITE_ROLES vía requireMembership) y misma forma de batch
+ * todo-o-nada: si una key del body es desconocida, no se borra ninguna.
+ *
+ * Borrar una key que no tiene fila hoy no es un error — DELETE es
+ * idempotente por naturaleza (0 filas afectadas sigue siendo 200).
+ */
+export async function DELETE(req: NextRequest) {
+  const SUPA_URL = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const SUPA_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  if (!SUPA_URL || !SUPA_KEY) {
+    console.error('[api/business-config] Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY')
+    return NextResponse.json({ error: 'Configuración de servidor incompleta' }, { status: 500 })
+  }
+
+  const location_id = req.nextUrl.searchParams.get('location_id')
+  if (!location_id) {
+    return NextResponse.json({ error: 'Falta location_id (query param)' }, { status: 400 })
+  }
+
+  const authResult = await requireMembership(req, location_id, { roles: WRITE_ROLES })
+  if (authResult instanceof Response) return authResult
+
+  let body: DeleteBody
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: 'Body inválido: se esperaba JSON' }, { status: 400 })
+  }
+
+  const keys = body.keys
+  if (!Array.isArray(keys) || keys.length === 0) {
+    return NextResponse.json({ error: 'Falta "keys": array de string no vacío' }, { status: 400 })
+  }
+
+  // Validar TODO antes de borrar nada — mismo criterio todo-o-nada que POST.
+  for (const key of keys) {
+    if (typeof key !== 'string' || !isBusinessConfigKey(key)) {
+      return NextResponse.json(
+        { error: `Clave desconocida: "${key}". Claves válidas: ${Object.keys(BUSINESS_CONFIG_KEYS).join(', ')}` },
+        { status: 400 },
+      )
+    }
+  }
+
+  try {
+    const keysFilter = `(${keys.map(k => `"${k}"`).join(',')})`
+    const deleteRes = await fetch(
+      `${SUPA_URL}/rest/v1/location_business_config?location_id=eq.${location_id}&key=in.${keysFilter}`,
+      {
+        method:  'DELETE',
+        headers: {
+          'apikey':        SUPA_KEY,
+          'Authorization': `Bearer ${SUPA_KEY}`,
+          'Prefer':        'return=minimal',
+        },
+      },
+    )
+    if (!deleteRes.ok) {
+      const text = await deleteRes.text()
+      throw new Error(`DELETE falló status=${deleteRes.status}: ${text}`)
+    }
+
+    return NextResponse.json({ success: true, deleted: keys })
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err)
     console.error('[api/business-config] error:', msg)

--- a/docs/qa/H3-PARTE-A-BUSINESS-CONFIG.md
+++ b/docs/qa/H3-PARTE-A-BUSINESS-CONFIG.md
@@ -82,7 +82,9 @@ el resto de las convenciones de escala.
   valida tipo jsonb + rango numérico básico por unit.
 - **RLS**: `user_has_membership()` para SELECT (cualquier rol con membership
   activa). `user_has_write_role()` — función nueva, espejo SQL de
-  `lib/authz.ts WRITE_ROLES` — para INSERT/UPDATE.
+  `lib/authz.ts WRITE_ROLES` — para INSERT/UPDATE/DELETE (DELETE agregado
+  2026-08-27, `20260827000001_location_business_config_delete.sql`, misma
+  función, sin duplicar).
 - **App**: `/api/business-config` usa `requireMembership(..., { roles: WRITE_ROLES })`
   antes de escribir vía `service_role`, más validación de forma completa
   (`lib/business-config.ts`, rango real por unidad).
@@ -132,6 +134,32 @@ una entrada del batch es inválida, no se escribe ninguna.
 y unidades en `BUSINESS_CONFIG_KEYS` (`lib/business-config.ts`) — es la fuente
 de verdad, no hardcodear los rangos de nuevo en un componente.
 
+**Borrado** (2026-08-27) — `DELETE /api/business-config?location_id=<uuid>`,
+body `{ keys: [<string>, ...] }`. Única forma de volver una clave a "no
+configurado" (fila ausente). **No existe ningún atajo que lo infiera**: no hay
+PATCH con `value: null`, y escribir `0` vía POST NO es "borrar" — es configurar
+la clave con el valor 0, algo completamente distinto de "no configurado". Si
+necesitás que la UI ofrezca "quitar este valor", andá por acá, no por un POST
+con un valor mágico.
+
+Mismo gate que POST (`requireMembership(..., { roles: WRITE_ROLES })` — un
+`manager`/`encargado`/`staff` recibe 403) y mismo criterio todo-o-nada: si una
+key del batch es desconocida, no se borra ninguna.
+
+| Situación | Status | Body de respuesta |
+|---|---|---|
+| Éxito (incluida una key sin fila previa — DELETE es idempotente) | `200` | `{ success: true, deleted: [<keys pedidas>] }` |
+| Falta `location_id` (query param) | `400` | `{ error: '...' }` |
+| Body inválido / falta `keys` / `keys` vacío | `400` | `{ error: '...' }` |
+| Alguna key del batch no existe en `BUSINESS_CONFIG_KEYS` | `400` | `{ error: '...' }` — no se borra ninguna |
+| Sin sesión válida | `401` | `{ error: 'Unauthorized' }` |
+| Sin membership activa en `location_id`, o rol fuera de `WRITE_ROLES` | `403` | `{ error: '...' }` |
+| Falla el DELETE en Postgres/PostgREST | `500` | `{ error: '...' }` |
+
+`deleted` en la respuesta 200 son las keys que se **pidió** borrar, no las que
+tenían fila — pedir borrar una key ya ausente es un no-op válido, no un error
+("no configurado" borrado de nuevo sigue siendo "no configurado").
+
 ## Verificación en STG — sesión autenticada real
 
 ⚠️ **No se usó `service_role` para verificar.** Con el gate
@@ -173,6 +201,37 @@ Verificación H3 Parte A — location_business_config — STG
 Dato de prueba (`benchmark_laboral_pct=32` en Demo Ituzaingó) borrado después
 de verificar, para no interferir con el testing de Codex en Parte B — STG
 quedó en 0 filas en `location_business_config`.
+
+## Verificación en STG — DELETE (2026-08-27)
+
+Migración `20260827000001_location_business_config_delete.sql` aplicada a STG
+antes de verificar (policy + GRANT DELETE nuevos, nada existente tocado).
+Mismo criterio que Parte A: sesión real, nunca `service_role`
+(`scripts/verify-business-config-delete-stg.ts`).
+
+```
+Verificación DELETE /api/business-config — STG
+  ✓  login qa-owner
+  ✓  login qa-manager
+  ✓  Precondición — sin config previa para benchmark_laboral_pct
+  ✓  Caso 1a — qa-owner escribe benchmark_laboral_pct=45
+  ✓  Caso 1b — confirmado: la lectura ve el valor recién escrito
+  ✓  Caso 1c — qa-owner borra benchmark_laboral_pct (clave EXISTENTE) → 200
+  ✓  Caso 1d — confirmado: tras el DELETE, la RPC vuelve a devolver 0 filas (no configurado, no value=0)
+  ✓  Caso 2 — qa-owner borra mc_objetivo_pct (clave que NUNCA existió acá) → 200, no-op
+  ✓  Caso 3 — qa-manager NO puede borrar (rol fuera de WRITE_ROLES) → 403
+  ✓  Limpieza — borrar cv_umbral_saludable_pct que quedó del Caso 3 y confirmar 0 filas
+
+10/10 passed
+```
+
+Escrito y borrado durante la verificación: `benchmark_laboral_pct=45` (Caso 1,
+escrito y borrado en el mismo test) y `cv_umbral_saludable_pct=37` (Caso 3,
+escrito para que el manager tuviera algo real que intentar borrar, borrado en
+la limpieza final). `mc_objetivo_pct` en el Caso 2 nunca llegó a tener fila —
+es el caso "borrar una clave que no existe". Confirmado por query directa
+(`SELECT count(*) FROM location_business_config`) que STG terminó en 0 filas,
+igual que al empezar.
 
 ## Nota de proceso — worktree aislado
 

--- a/scripts/verify-business-config-delete-stg.ts
+++ b/scripts/verify-business-config-delete-stg.ts
@@ -1,0 +1,182 @@
+/**
+ * Verificación H3 Parte A — DELETE /api/business-config, con sesiones
+ * autenticadas REALES contra STG (nunca service_role: con el gate
+ * user_has_write_role, service_role devuelve vacío en vez de error, lo que
+ * puede hacer pasar un test que en realidad está roto).
+ *
+ * Uso: npx tsx scripts/verify-business-config-delete-stg.ts
+ * Requiere el dev server de Next corriendo contra STG (la escritura/borrado
+ * pasa por app/api/business-config, no por una RPC). DEV_SERVER_URL
+ * (default http://localhost:3401) apunta a esa instancia.
+ */
+
+import * as fs from 'fs'
+import * as path from 'path'
+
+function loadEnv(file: string): Record<string, string> {
+  const envPath = path.resolve(process.cwd(), file)
+  if (!fs.existsSync(envPath)) return {}
+  return Object.fromEntries(
+    fs.readFileSync(envPath, 'utf8')
+      .split('\n')
+      .filter(l => l.trim() && !l.startsWith('#') && l.includes('='))
+      .map(l => { const [k, ...v] = l.split('='); return [k.trim(), v.join('=').trim()] }),
+  )
+}
+
+const env = { ...loadEnv('.env.staging'), ...loadEnv('.env.stg-test-users'), ...process.env }
+
+const SUPA_URL       = env.NEXT_PUBLIC_SUPABASE_URL
+const ANON_KEY       = env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+const DEV_SERVER_URL = env.DEV_SERVER_URL ?? 'http://localhost:3401'
+
+const DEMO_ITUZAINGO_LOCATION_ID = 'bbbbbbbb-0000-0000-0000-000000000001' // qa-owner: role=owner acá
+
+if (!SUPA_URL || !ANON_KEY || !env.QA_OWNER_EMAIL || !env.QA_OWNER_PASSWORD || !env.QA_MANAGER_EMAIL || !env.QA_MANAGER_PASSWORD) {
+  console.error('❌  Faltan credenciales en .env.staging / .env.stg-test-users')
+  process.exit(1)
+}
+
+async function login(email: string, password: string): Promise<string> {
+  const res = await fetch(`${SUPA_URL}/auth/v1/token?grant_type=password`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'apikey': ANON_KEY! },
+    body: JSON.stringify({ email, password }),
+  })
+  if (!res.ok) throw new Error(`Login ${email} falló: ${res.status} ${await res.text()}`)
+  const json = await res.json() as { access_token?: string }
+  if (!json.access_token) throw new Error(`Login ${email} no devolvió access_token`)
+  return json.access_token
+}
+
+async function readConfig(jwt: string, locationId: string): Promise<Array<{ key: string; value: unknown; unit: string }>> {
+  const res = await fetch(`${SUPA_URL}/rest/v1/rpc/get_location_business_config`, {
+    method: 'POST',
+    headers: {
+      'Content-Type':  'application/json',
+      'apikey':        ANON_KEY!,
+      'Authorization': `Bearer ${jwt}`,
+    },
+    body: JSON.stringify({ p_location_id: locationId }),
+  })
+  if (!res.ok) throw new Error(`RPC get_location_business_config error ${res.status}: ${await res.text()}`)
+  return res.json() as Promise<Array<{ key: string; value: unknown; unit: string }>>
+}
+
+async function writeConfig(jwt: string, locationId: string, entries: Array<{ key: string; value: unknown }>) {
+  const res = await fetch(`${DEV_SERVER_URL}/api/business-config?location_id=${locationId}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${jwt}` },
+    body: JSON.stringify({ entries }),
+  })
+  const json = await res.json().catch(() => ({}))
+  return { status: res.status, json }
+}
+
+async function deleteConfig(jwt: string, locationId: string, keys: string[]) {
+  const res = await fetch(`${DEV_SERVER_URL}/api/business-config?location_id=${locationId}`, {
+    method: 'DELETE',
+    headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${jwt}` },
+    body: JSON.stringify({ keys }),
+  })
+  const json = await res.json().catch(() => ({}))
+  return { status: res.status, json }
+}
+
+type TestResult = { name: string; ok: boolean; detail: string }
+const results: TestResult[] = []
+
+async function test(name: string, fn: () => Promise<void>) {
+  try {
+    await fn()
+    results.push({ name, ok: true, detail: 'OK' })
+  } catch (e: unknown) {
+    results.push({ name, ok: false, detail: e instanceof Error ? e.message : String(e) })
+  }
+}
+
+function assert(cond: boolean, msg: string) {
+  if (!cond) throw new Error(msg)
+}
+
+async function run() {
+  console.log(`\nVerificación DELETE /api/business-config — STG (${SUPA_URL})\n`)
+
+  let ownerJwt = ''
+  let managerJwt = ''
+
+  await test('login qa-owner', async () => { ownerJwt = await login(env.QA_OWNER_EMAIL!, env.QA_OWNER_PASSWORD!) })
+  await test('login qa-manager', async () => { managerJwt = await login(env.QA_MANAGER_EMAIL!, env.QA_MANAGER_PASSWORD!) })
+
+  if (!ownerJwt || !managerJwt) {
+    console.error('\n❌  Login falló — no se puede continuar\n')
+    for (const r of results) console.log(`  ${r.ok ? '✓' : '✗'}  ${r.name}${r.ok ? '' : `  → ${r.detail}`}`)
+    process.exit(1)
+  }
+
+  // ── Precondición: la location arranca sin config (limpio de sesiones previas) ──
+  await test('Precondición — sin config previa para benchmark_laboral_pct', async () => {
+    const rows = await readConfig(ownerJwt, DEMO_ITUZAINGO_LOCATION_ID)
+    const pre = rows.filter(r => r.key === 'benchmark_laboral_pct')
+    assert(pre.length === 0, `esperaba 0 filas antes de escribir; vino ${JSON.stringify(pre)}`)
+  })
+
+  // ── Caso 1: escribir, confirmar, borrar clave EXISTENTE, confirmar ausencia ──
+  await test('Caso 1a — qa-owner escribe benchmark_laboral_pct=45', async () => {
+    const { status, json } = await writeConfig(ownerJwt, DEMO_ITUZAINGO_LOCATION_ID, [
+      { key: 'benchmark_laboral_pct', value: 45 },
+    ])
+    assert(status === 200, `esperaba 200, vino ${status}: ${JSON.stringify(json)}`)
+  })
+
+  await test('Caso 1b — confirmado: la lectura ve el valor recién escrito', async () => {
+    const rows = await readConfig(ownerJwt, DEMO_ITUZAINGO_LOCATION_ID)
+    const row = rows.find(r => r.key === 'benchmark_laboral_pct')
+    assert(!!row && row.value === 45, `esperaba value=45, vino ${JSON.stringify(row)}`)
+  })
+
+  await test('Caso 1c — qa-owner borra benchmark_laboral_pct (clave EXISTENTE) → 200', async () => {
+    const { status, json } = await deleteConfig(ownerJwt, DEMO_ITUZAINGO_LOCATION_ID, ['benchmark_laboral_pct'])
+    assert(status === 200, `esperaba 200, vino ${status}: ${JSON.stringify(json)}`)
+    assert(Array.isArray(json.deleted) && json.deleted.includes('benchmark_laboral_pct'), `esperaba deleted incluya la key, vino ${JSON.stringify(json)}`)
+  })
+
+  await test('Caso 1d — confirmado: tras el DELETE, la RPC vuelve a devolver 0 filas (no configurado, no value=0)', async () => {
+    const rows = await readConfig(ownerJwt, DEMO_ITUZAINGO_LOCATION_ID)
+    const post = rows.filter(r => r.key === 'benchmark_laboral_pct')
+    assert(post.length === 0, `esperaba 0 filas tras el DELETE; vino ${JSON.stringify(post)}`)
+  })
+
+  // ── Caso 2: borrar una clave que NUNCA tuvo fila → no es error ──────────────
+  await test('Caso 2 — qa-owner borra mc_objetivo_pct (clave que NUNCA existió acá) → 200, no-op', async () => {
+    const rows = await readConfig(ownerJwt, DEMO_ITUZAINGO_LOCATION_ID)
+    assert(rows.filter(r => r.key === 'mc_objetivo_pct').length === 0, 'precondición rota: mc_objetivo_pct ya tenía fila')
+    const { status, json } = await deleteConfig(ownerJwt, DEMO_ITUZAINGO_LOCATION_ID, ['mc_objetivo_pct'])
+    assert(status === 200, `esperaba 200 (DELETE de una key sin fila no es error), vino ${status}: ${JSON.stringify(json)}`)
+  })
+
+  // ── Caso 3: qa-manager intenta borrar → rechazado ───────────────────────────
+  await test('Caso 3 — qa-manager NO puede borrar (rol fuera de WRITE_ROLES) → 403', async () => {
+    // Escribimos con el owner primero para tener algo real que el manager intente borrar.
+    await writeConfig(ownerJwt, DEMO_ITUZAINGO_LOCATION_ID, [{ key: 'cv_umbral_saludable_pct', value: 37 }])
+    const { status } = await deleteConfig(managerJwt, DEMO_ITUZAINGO_LOCATION_ID, ['cv_umbral_saludable_pct'])
+    assert(status === 403, `esperaba 403, vino ${status}`)
+  })
+
+  // ── Limpieza final: dejar STG en 0 filas, como al empezar ───────────────────
+  await test('Limpieza — borrar cv_umbral_saludable_pct que quedó del Caso 3 y confirmar 0 filas', async () => {
+    await deleteConfig(ownerJwt, DEMO_ITUZAINGO_LOCATION_ID, ['cv_umbral_saludable_pct'])
+    const rows = await readConfig(ownerJwt, DEMO_ITUZAINGO_LOCATION_ID)
+    assert(rows.length === 0, `esperaba STG en 0 filas tras la limpieza; quedó ${JSON.stringify(rows)}`)
+  })
+
+  const passed = results.filter(r => r.ok).length
+  const failed = results.filter(r => !r.ok).length
+
+  console.log('Resultados:')
+  for (const r of results) console.log(`  ${r.ok ? '✓' : '✗'}  ${r.name}${r.ok ? '' : `  → ${r.detail}`}`)
+  console.log(`\n${passed}/${results.length} passed`)
+  if (failed > 0) process.exit(1)
+}
+
+run().catch(e => { console.error('Fatal:', e); process.exit(1) })

--- a/supabase/migrations/20260827000001_location_business_config_delete.sql
+++ b/supabase/migrations/20260827000001_location_business_config_delete.sql
@@ -1,0 +1,28 @@
+-- ============================================================
+-- Migration: location_business_config — DELETE
+-- Fecha: 2026-08-27
+--
+-- H3 Parte A dejó configurar una clave (POST /api/business-config)
+-- pero no volverla a "no configurado": no había policy ni GRANT de
+-- DELETE en location_business_config. Codex quedó bloqueado en
+-- Parte B — la UI puede cargar valores pero nunca desconfigurarlos.
+--
+-- Migración aditiva: no toca la tabla, el CHECK, ni las policies
+-- de SELECT/INSERT/UPDATE de 20260826000001_location_business_config.sql.
+-- Mismo criterio de autorización que INSERT/UPDATE (user_has_write_role,
+-- ya creada en esa migración — no se recrea acá).
+--
+-- Explícito a propósito: borrar una fila es la única forma de volver a
+-- "no configurado" (fila ausente). No hay endpoint que ponga value=0
+-- ni que infiera "borrar" de un PATCH con null — ver docstring de
+-- lib/business-config.ts y el contrato en
+-- docs/qa/H3-PARTE-A-BUSINESS-CONFIG.md.
+-- ============================================================
+
+CREATE POLICY location_business_config_delete
+  ON public.location_business_config
+  FOR DELETE
+  TO authenticated
+  USING (public.user_has_write_role(location_id));
+
+GRANT DELETE ON public.location_business_config TO authenticated;

--- a/tests/api-business-config.test.ts
+++ b/tests/api-business-config.test.ts
@@ -140,3 +140,115 @@ describe('POST /api/business-config', () => {
     expect(res.status).toBe(500)
   })
 })
+
+function makeDeleteReq(locationId: string | null, body: unknown) {
+  const url = locationId
+    ? `http://localhost/api/business-config?location_id=${locationId}`
+    : 'http://localhost/api/business-config'
+  return new NextRequest(url, {
+    method: 'DELETE',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('DELETE /api/business-config', () => {
+  it('400 — falta location_id', async () => {
+    const { DELETE } = await import('@/app/api/business-config/route')
+    const res = await DELETE(makeDeleteReq(null, { keys: ['benchmark_laboral_pct'] }))
+    expect(res.status).toBe(400)
+    expect(mockRequireMembership).not.toHaveBeenCalled()
+  })
+
+  it('delega el gate de rol a requireMembership con opts.roles = WRITE_ROLES', async () => {
+    const { WRITE_ROLES } = await import('@/lib/authz')
+    const { DELETE } = await import('@/app/api/business-config/route')
+    await DELETE(makeDeleteReq('loc-1', { keys: ['benchmark_laboral_pct'] }))
+
+    expect(mockRequireMembership).toHaveBeenCalledWith(
+      expect.anything(),
+      'loc-1',
+      { roles: WRITE_ROLES },
+    )
+  })
+
+  it('propaga el rechazo de requireMembership (403 — manager fuera de WRITE_ROLES) sin llegar a borrar', async () => {
+    mockRequireMembership.mockResolvedValue(
+      new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403 }),
+    )
+    const { DELETE } = await import('@/app/api/business-config/route')
+    const res = await DELETE(makeDeleteReq('loc-1', { keys: ['benchmark_laboral_pct'] }))
+
+    expect(res.status).toBe(403)
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('400 — keys vacío o ausente', async () => {
+    const { DELETE } = await import('@/app/api/business-config/route')
+    const res = await DELETE(makeDeleteReq('loc-1', {}))
+    expect(res.status).toBe(400)
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('400 — key desconocida, no borra nada', async () => {
+    const { DELETE } = await import('@/app/api/business-config/route')
+    const res = await DELETE(makeDeleteReq('loc-1', { keys: ['no_existe'] }))
+    expect(res.status).toBe(400)
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('400 — un batch con UNA key desconocida no borra NINGUNA (todo o nada)', async () => {
+    const { DELETE } = await import('@/app/api/business-config/route')
+    const res = await DELETE(makeDeleteReq('loc-1', { keys: ['benchmark_laboral_pct', 'no_existe'] }))
+    expect(res.status).toBe(400)
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('200 — borra una clave existente vía service_role con location_id=eq. y key=in.(...)', async () => {
+    const { DELETE } = await import('@/app/api/business-config/route')
+    const res = await DELETE(makeDeleteReq('loc-1', { keys: ['benchmark_laboral_pct'] }))
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.success).toBe(true)
+    expect(body.deleted).toEqual(['benchmark_laboral_pct'])
+
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    const [url, init] = mockFetch.mock.calls[0]
+    expect(String(url)).toContain('/rest/v1/location_business_config')
+    expect(String(url)).toContain('location_id=eq.loc-1')
+    expect(String(url)).toContain('key=in.')
+    expect(String(url)).toContain('benchmark_laboral_pct')
+    expect(init.method).toBe('DELETE')
+  })
+
+  it('200 — borrar una clave sin fila previa es un no-op válido, no un error (DELETE es idempotente)', async () => {
+    // El mock de fetch simula el mismo 200 que devuelve PostgREST cuando el
+    // filtro no matchea ninguna fila — DELETE no distingue "borré 1" de
+    // "borré 0", ninguno de los dos es un error.
+    mockFetch.mockResolvedValue(new Response(null, { status: 200 }))
+    const { DELETE } = await import('@/app/api/business-config/route')
+    const res = await DELETE(makeDeleteReq('loc-1', { keys: ['mc_objetivo_pct'] }))
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.success).toBe(true)
+    expect(body.deleted).toEqual(['mc_objetivo_pct'])
+  })
+
+  it('200 — batch de varias keys en un solo DELETE', async () => {
+    const { DELETE } = await import('@/app/api/business-config/route')
+    const res = await DELETE(makeDeleteReq('loc-1', { keys: ['benchmark_laboral_pct', 'mc_objetivo_pct'] }))
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.deleted).toEqual(['benchmark_laboral_pct', 'mc_objetivo_pct'])
+  })
+
+  it('500 — el DELETE falla en Postgres/PostgREST', async () => {
+    mockFetch.mockResolvedValue(new Response('db error', { status: 500 }))
+    const { DELETE } = await import('@/app/api/business-config/route')
+    const res = await DELETE(makeDeleteReq('loc-1', { keys: ['benchmark_laboral_pct'] }))
+    expect(res.status).toBe(500)
+  })
+})


### PR DESCRIPTION
## Summary
- Codex estaba bloqueado: POST podía configurar una clave pero no había forma de volverla a "no configurado" (fila ausente).
- Migración aditiva `20260827000001_location_business_config_delete.sql`: policy de DELETE con `user_has_write_role(location_id)` (misma función que INSERT/UPDATE, no se duplica) + `GRANT DELETE` a `authenticated`. No toca la tabla, el CHECK, ni las policies existentes de `20260826000001_location_business_config.sql`.
- Handler `DELETE /api/business-config?location_id=<uuid>`, body `{ keys: [...] }` — misma forma que POST: `requireMembership(..., { roles: WRITE_ROLES })`, batch todo-o-nada, mismos códigos 400/401/403/500. Borrar una key sin fila previa es un **200 no-op**, no un error (DELETE es idempotente).
- **Explícito a propósito**: no hay PATCH con `value: null` ni ningún atajo que infiera "borrar" de otra operación. Escribir `0` vía POST configura la clave con valor 0 — no es lo mismo que "no configurado".
- `docs/qa/H3-PARTE-A-BUSINESS-CONFIG.md` actualizado con el contrato completo (tabla de status codes) para que Codex lo use en Parte B.

## Verificación en STG — sesión real, nunca `service_role`
`service_role` devuelve vacío bajo `user_has_write_role` — daría falso positivo. Se usó login real (`qa-owner`/`qa-manager`) + el route handler real corriendo contra STG (`scripts/verify-business-config-delete-stg.ts`):

```
✓  login qa-owner
✓  login qa-manager
✓  Precondición — sin config previa para benchmark_laboral_pct
✓  Caso 1a — qa-owner escribe benchmark_laboral_pct=45
✓  Caso 1b — confirmado: la lectura ve el valor recién escrito
✓  Caso 1c — qa-owner borra benchmark_laboral_pct (clave EXISTENTE) → 200
✓  Caso 1d — confirmado: tras el DELETE, la RPC vuelve a devolver 0 filas (no configurado, no value=0)
✓  Caso 2 — qa-owner borra mc_objetivo_pct (clave que NUNCA existió acá) → 200, no-op
✓  Caso 3 — qa-manager NO puede borrar (rol fuera de WRITE_ROLES) → 403
✓  Limpieza — borrar cv_umbral_saludable_pct que quedó del Caso 3 y confirmar 0 filas

10/10 passed
```

**Qué se escribió y qué se borró**: `benchmark_laboral_pct=45` (Caso 1, escrito y borrado en el mismo test) y `cv_umbral_saludable_pct=37` (Caso 3, escrito para que el manager tuviera algo real que intentar borrar, borrado en la limpieza final). `mc_objetivo_pct` (Caso 2) nunca tuvo fila — ese es el caso "borrar una clave que no existe". Confirmado por query directa a STG (`SELECT count(*) FROM location_business_config`) → **0 filas al terminar, igual que al empezar**.

La migración de policy/grant también se aplicó a STG antes de verificar (vía Management API, mismo mecanismo que `scripts/estado-real.ts` usa para leer) — sin eso el DELETE vía `service_role` en el handler igual hubiera funcionado (bypassa RLS), pero quería la segunda capa de defensa realmente probada, no solo declarada.

## SQL para PROD

```sql
-- ============================================================
-- Migration: location_business_config — DELETE
-- Fecha: 2026-08-27
--
-- H3 Parte A dejó configurar una clave (POST /api/business-config)
-- pero no volverla a "no configurado": no había policy ni GRANT de
-- DELETE en location_business_config. Codex quedó bloqueado en
-- Parte B — la UI puede cargar valores pero nunca desconfigurarlos.
--
-- Migración aditiva: no toca la tabla, el CHECK, ni las policies
-- de SELECT/INSERT/UPDATE de 20260826000001_location_business_config.sql.
-- Mismo criterio de autorización que INSERT/UPDATE (user_has_write_role,
-- ya creada en esa migración — no se recrea acá).
--
-- Explícito a propósito: borrar una fila es la única forma de volver a
-- "no configurado" (fila ausente). No hay endpoint que ponga value=0
-- ni que infiera "borrar" de un PATCH con null — ver docstring de
-- lib/business-config.ts y el contrato en
-- docs/qa/H3-PARTE-A-BUSINESS-CONFIG.md.
-- ============================================================

CREATE POLICY location_business_config_delete
  ON public.location_business_config
  FOR DELETE
  TO authenticated
  USING (public.user_has_write_role(location_id));

GRANT DELETE ON public.location_business_config TO authenticated;
```

Prerequisito: `20260826000001_location_business_config.sql` (tabla + `user_has_write_role`) tiene que estar aplicada en PROD antes que esta.

## Test plan
- [x] `npx vitest run tests/api-business-config.test.ts` — 19/19 (10 nuevos para DELETE: 400 sin location_id, delega gate a requireMembership, propaga 403, 400 keys vacío, 400 key desconocida, 400 batch todo-o-nada, 200 clave existente, 200 clave inexistente no-op, 200 batch, 500 falla DB)
- [x] `npx tsc --noEmit` — limpio
- [x] `npx eslint src/ app/` — limpio
- [x] `npx vitest run` completo — 329 passed, 3 failed (preexistentes, no relacionados — ver nota sobre `tests/business-config-registry.test.ts` y CRLF en Windows), 30 skipped
- [x] Verificación real contra STG (arriba) — 10/10, limpieza confirmada